### PR TITLE
Fix Analyzer bug

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -2,7 +2,6 @@ package ssainspect
 
 import (
 	"errors"
-	"iter"
 	"reflect"
 
 	"golang.org/x/tools/go/analysis"
@@ -11,12 +10,12 @@ import (
 
 var Analyzer = &analysis.Analyzer{
 	Name: "ssainspect",
-	Doc:  "make iter.Seq[*ssainspect.Cursor]",
+	Doc:  "make an Inspector",
 	Run:  runAnalyzer,
 	Requires: []*analysis.Analyzer{
 		buildssa.Analyzer,
 	},
-	ResultType: reflect.TypeFor[iter.Seq[*Cursor]](),
+	ResultType: reflect.TypeFor[*Inspector](),
 }
 
 func runAnalyzer(pass *analysis.Pass) (any, error) {
@@ -24,5 +23,5 @@ func runAnalyzer(pass *analysis.Pass) (any, error) {
 	if !ok {
 		return nil, errors.New("failed to get result of buildssa.Analyzer")
 	}
-	return All(ssa.SrcFuncs), nil
+	return New(ssa.SrcFuncs), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -22,3 +22,7 @@ require (
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )
+
+retract (
+	v0.2.0 // including a bug in Analyzer
+)

--- a/ssainspect.go
+++ b/ssainspect.go
@@ -2,6 +2,7 @@ package ssainspect
 
 import (
 	"iter"
+	"slices"
 
 	"github.com/gostaticanalysis/analysisutil"
 	"golang.org/x/tools/go/ssa"
@@ -39,9 +40,27 @@ func (cur *Cursor) InCycle() bool {
 			continue
 		}
 		done[b] = struct{}{}
-		blocks = append(b.Succs, blocks...)
+		blocks = append(slices.Clone(b.Succs), blocks...)
 	}
 	return false
+}
+
+// Inspector provides an iterator which iterats all SSA functions, basic blocks and instructions.
+type Inspector struct {
+	cursors []*Cursor
+}
+
+// New creates [Inspector].
+func New(funcs []*ssa.Function) *Inspector {
+	return &Inspector{
+		cursors: slices.Collect(All(funcs)),
+	}
+}
+
+// All returns an iterator which inspects all SSA functions, basic blocks and instructions.
+// The iteration result is cached in [Inspector].
+func (i *Inspector) All() iter.Seq[*Cursor] {
+	return slices.Values(i.cursors)
 }
 
 // All returns an iterator which inspects all SSA functions, basic blocks and instructions.

--- a/testdata/b.golden
+++ b/testdata/b.golden
@@ -1,0 +1,14 @@
+Func b.g
+Block 0 InCycle= false
+	 println("b":string)
+	 jump 1
+Block 1 InCycle= true
+	 phi [0: 0:int, 2: t4] #i
+	 t1 < 10:int
+	 if t2 goto 2 else 3
+Block 2 InCycle= true
+	 println("b":string)
+	 t1 + 1:int
+	 jump 1
+Block 3 InCycle= false
+	 return

--- a/testdata/src/b/b.go
+++ b/testdata/src/b/b.go
@@ -1,0 +1,8 @@
+package b
+
+func g() {
+	println("b")
+	for i := 0; i < 10; i++ {
+		println("b")
+	}
+}


### PR DESCRIPTION
The analyzer has a bug which iterates once per package in v0.2.0.
The result of analyzer changed from iter.Seq[*Cursor] to *Inspector.
This change breaks backward compatibillity.
The V0.2.0 becomes retract version.
